### PR TITLE
fix: Hide scrollbar when windows taskbar hides automatically

### DIFF
--- a/packages/screen/src/screen.css
+++ b/packages/screen/src/screen.css
@@ -1,5 +1,6 @@
 .screen {
   height: 100vh;
+  position: relative;
   overflow: hidden;
   font-size: 64px;
   font-weight: bold;


### PR DESCRIPTION
The CSS propety overflow:hidden of a element is ignored if a child
of the element has position:absolute and the element does not have
position:relative.