### PR TITLE
fix: handling for IME composition

### DIFF
--- a/packages/app/src/comment/SendCommentForm.spec.tsx
+++ b/packages/app/src/comment/SendCommentForm.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { SendCommentForm } from './SendCommentForm'
 import '@testing-library/jest-dom'
@@ -38,6 +38,19 @@ test('Input text and press Enter key.', async () => {
     type: 'comment',
     comment: inputText,
   })
+})
+
+test('Input text and press Enter key while composing.', async () => {
+  const onSubmit = jest.fn()
+  render(<SendCommentForm onSubmit={onSubmit} sendWithCtrlEnter={false}/>)
+
+  const inputText = '入力中'
+  const textBox = screen.getByRole('textbox', { name: '' }) as HTMLInputElement
+  userEvent.type(textBox, inputText)
+  fireEvent.keyDown(textBox, { key: 'Enter', code: 'Enter', isComposing: true })
+
+  expect(textBox.value).toBe(inputText)
+  expect(onSubmit).not.toBeCalled()
 })
 
 test('Input text and click button with "send with ctrl+enter" option.', async () => {

--- a/packages/app/src/comment/SendCommentForm.tsx
+++ b/packages/app/src/comment/SendCommentForm.tsx
@@ -62,6 +62,11 @@ export class SendCommentForm extends Component<PropsType, StateType> {
   }
 
   private onKeyDown = (e: KeyboardEvent<HTMLInputElement>): void => {
+    // Do not send while IME composition is active; Enter may only confirm conversion.
+    if (e.nativeEvent.isComposing) {
+      return
+    }
+
     const ctrlModifierState = !this.getControlModifierState
       ? e.getModifierState('Control')
       : this.getControlModifierState()


### PR DESCRIPTION
コメント送信時、変換中に Enter を押すとコメントが送信されてしまう問題に対応しました。